### PR TITLE
Add support for MarkerCluster dynamic icons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -226,3 +226,6 @@ $RECYCLE.BIN/
 
 # Windows shortcuts
 *.lnk
+
+# IDE files
+.idea/

--- a/examples/dynamic_icon_url_example.html
+++ b/examples/dynamic_icon_url_example.html
@@ -1,0 +1,109 @@
+<!DOCTYPE >
+<html>
+  <head>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+    <title>MarkerClustererPlus V3 Example</title>
+
+    <style type="text/css">
+      body {
+        margin: 0;
+        padding: 10px 20px 20px;
+        font-family: Arial;
+        font-size: 16px;
+      }
+
+      #map-container {
+        padding: 6px;
+        border-width: 1px;
+        border-style: solid;
+        border-color: #ccc #ccc #999 #ccc;
+        -webkit-box-shadow: rgba(64, 64, 64, 0.5) 0 2px 5px;
+        -moz-box-shadow: rgba(64, 64, 64, 0.5) 0 2px 5px;
+        box-shadow: rgba(64, 64, 64, 0.1) 0 2px 5px;
+        width: 600px;
+      }
+
+      #map {
+        width: 600px;
+        height: 400px;
+      }
+    </style>
+
+    <script src="https://maps.googleapis.com/maps/api/js?v=3&amp;sensor=false"></script>
+    <script type="text/javascript" src="data.js"></script>
+    <script
+      type="text/javascript"
+      src="../dist/index.min.js"
+    ></script>
+
+    <script type="text/javascript">
+      const styleCluster = [
+        MarkerClusterer.withDefaultStyle({
+          width: 50,
+          height: 64,
+          anchorIcon: [32, 25],
+          textColor: "red",
+          textSize: 10,
+        }),
+        MarkerClusterer.withDefaultStyle({
+          width: 100,
+          height: 128,
+          anchorIcon: [64, 50],
+          textColor: "blue",
+          textSize: 10,
+        }),
+      ];
+
+      function initialize() {
+        var center = new google.maps.LatLng(37.4419, -122.1419);
+
+        var map = new google.maps.Map(document.getElementById("map"), {
+          zoom: 3,
+          center: center,
+          mapTypeId: google.maps.MapTypeId.ROADMAP,
+        });
+
+        var markers = [];
+        for (var i = 0; i < 100; i++) {
+          var dataPhoto = data.photos[i];
+          var latLng = new google.maps.LatLng(
+            dataPhoto.latitude,
+            dataPhoto.longitude
+          );
+          var marker = new google.maps.Marker({
+            position: latLng,
+          });
+          markers.push(marker);
+        }
+        var markerCluster = new MarkerClusterer(map, markers, {
+          styles: styleCluster,
+          calculator: (clusterMarkers, numStyles) => {
+            let index = 0;
+            const count = clusterMarkers.length;
+
+            let dv = count;
+            while (dv !== 0) {
+              dv = Math.floor(dv / 10);
+              index++;
+            }
+
+            const iconUrl = `https://chart.googleapis.com/chart?chs=150x150&chd=t:${count},${markers.length}&cht=p3&chf=bg,s,FFFFFF00`
+
+            index = Math.min(index, numStyles);
+            return {
+              text: count.toString(),
+              url: iconUrl,
+              index: index,
+              title: "",
+            };
+          }
+        });
+      }
+      google.maps.event.addDomListener(window, "load", initialize);
+    </script>
+  </head>
+  <body>
+    <h3>Dynamic icon example for MarkerClustererPlus</h3>
+    <div id="map-container"><div id="map"></div></div>
+  </body>
+</html>

--- a/examples/dynamic_icon_url_example.html
+++ b/examples/dynamic_icon_url_example.html
@@ -49,14 +49,14 @@
           width: 50,
           height: 64,
           anchorIcon: [32, 25],
-          textColor: "red",
+          textColor: "yellow",
           textSize: 10,
         }),
         MarkerClusterer.withDefaultStyle({
           width: 100,
           height: 128,
           anchorIcon: [64, 50],
-          textColor: "blue",
+          textColor: "green",
           textSize: 10,
         }),
       ];

--- a/examples/dynamic_icon_url_example.html
+++ b/examples/dynamic_icon_url_example.html
@@ -39,6 +39,13 @@
     <script type="text/javascript">
       const styleCluster = [
         MarkerClusterer.withDefaultStyle({
+          width: 25,
+          height: 32,
+          anchorIcon: [16, 12.5],
+          textColor: "red",
+          textSize: 10,
+        }),
+        MarkerClusterer.withDefaultStyle({
           width: 50,
           height: 64,
           anchorIcon: [32, 25],

--- a/src/cluster-icon.ts
+++ b/src/cluster-icon.ts
@@ -141,6 +141,10 @@ export interface ClusterIconInfo {
    * value of the `title` property passed to the MarkerClusterer.
    */
   title: string;
+  /**
+   * An override for dynamic cluster icon url (if not provided, the component will use the default style icon)
+   */
+  url?: string;
 }
 
 /**
@@ -381,11 +385,16 @@ export class ClusterIcon extends OverlayViewSafe {
       };
     }
 
+    const overrideDimensionsDynamicIcon = this.sums_.url
+      ? { width: "100%", height: "100%" }
+      : {};
+
     const cssText = toCssText({
       position: "absolute",
       top: coercePixels(spriteV),
       left: coercePixels(spriteH),
       ...dimensions,
+      ...overrideDimensionsDynamicIcon,
     });
 
     return `<img alt="${this.sums_.text}" aria-hidden="true" src="${this.style.url}" style="${cssText}"/>`;
@@ -401,7 +410,9 @@ export class ClusterIcon extends OverlayViewSafe {
     this.sums_ = sums;
     let index = Math.max(0, sums.index - 1);
     index = Math.min(this.styles_.length - 1, index);
-    this.style = this.styles_[index];
+    this.style = this.sums_.url
+      ? { ...this.styles_[index], url: this.sums_.url }
+      : this.styles_[index];
 
     this.anchorText_ = this.style.anchorText || [0, 0];
     this.anchorIcon_ = this.style.anchorIcon || [


### PR DESCRIPTION
This PR implements the support for custom dynamic icons.

- Using the calculator function to generate icon based on dynamic data (in the example, plotting a pie chart with data based on `markers in cluster / total markers`.

https://user-images.githubusercontent.com/8743530/111647541-5649ca80-87e1-11eb-9cc1-bfaa04bba960.mov

