### PR TITLE
build: use @types/google.maps instead of @types/googlemaps

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "@babel/preset-env": "^7.11.5",
     "@babel/runtime-corejs3": "^7.11.2",
-    "@types/googlemaps": "^3.39.13",
+    "@types/google.maps": "^3.44.2",
     "@types/jest": "^26.0.13",
     "@types/selenium-webdriver": "^4.0.9",
     "@typescript-eslint/eslint-plugin": ">=4.1.0",

--- a/src/cluster-icon.ts
+++ b/src/cluster-icon.ts
@@ -213,12 +213,12 @@ export class ClusterIcon extends OverlayViewSafe {
     // But it doesn't work with earlier releases so do a version check.
     if (gmVersion >= 332) {
       // Ugly version-dependent code
-      google.maps.event.addDomListener(this.div_, "touchstart", (e) => {
+      google.maps.event.addDomListener(this.div_, "touchstart", (e: Event) => {
         e.stopPropagation();
       });
     }
 
-    google.maps.event.addDomListener(this.div_, "click", (e) => {
+    google.maps.event.addDomListener(this.div_, "click", (e: Event) => {
       cMouseDownInCluster = false;
       if (!cDraggingMapByCluster) {
         /**

--- a/src/markerclusterer.ts
+++ b/src/markerclusterer.ts
@@ -293,7 +293,8 @@ export class MarkerClusterer extends OverlayViewSafe {
 
   public ariaLabelFn = this.options.ariaLabelFn || ((): string => "");
 
-  private zIndex_ = this.options.zIndex || google.maps.Marker.MAX_ZINDEX + 1;
+  private zIndex_ =
+    this.options.zIndex || Number(google.maps.Marker.MAX_ZINDEX) + 1;
   private gridSize_ = this.options.gridSize || 60;
   private minClusterSize_ = this.options.minimumClusterSize || 2;
   private maxZoom_ = this.options.maxZoom || null;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "sourceMap": true,
     "esModuleInterop": true,
     "lib": ["DOM", "ESNext"],
-    "types": ["googlemaps"]
+    "types": ["google.maps"]
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
Hello,

First of all, thank you for this great library, very easy to use 👍

So, per [https://developers.google.com/maps/documentation/javascript/using-typescript](https://developers.google.com/maps/documentation/javascript/using-typescript),
the package used for google maps types should be `@types/google.maps`.

So I changed the dependency here and fixed a few types due to this.

As to why I decided to do it, I work on a project where I use markerclustererplus in addition to google maps, and since I followed the latest docs, I installed `@types/google.maps`.
It all works great, but typescript complains about some types being wrong, so I tried to install `@types/googlemaps` as well but it just creates a lot of errors.

`lint` gives the same only warning as before this change.
`format` formats only the example files, same as before the change.

Thanks !